### PR TITLE
add expose port to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get clean\
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # defaults
-
+EXPOSE 80 2003-2004 2023-2024 8125/udp 8126
 VOLUME ["/opt/graphite", "/etc/nginx", "/etc/logrotate.d", "/var/log"]
 ENV HOME /root
 CMD ["/sbin/my_init"]


### PR DESCRIPTION
add back EXPOSE to Dockerfile,
it makes easily to work with [nginx-proxy](https://github.com/jwilder/nginx-proxy) 
ex:

```
sudo docker run -d \
  --name graphite \
  -p 2003:2003 \
  -e VIRTUAL_HOST=graphite.foo.bar
  -e VIRTUAL_PORT=80
  sitespeedio/graphite
```
